### PR TITLE
MAINT: Change multi-word flags from _ to -

### DIFF
--- a/docs/command_line_interface.md
+++ b/docs/command_line_interface.md
@@ -1,19 +1,19 @@
 
 ```sh
-iris-gpubench [--benchmark_image BENCHMARK_IMAGE | --benchmark_command BENCHMARK_COMMAND] [--interval INTERVAL] [--carbon_region CARBON_REGION] [--live_plot] [--export_to_meerkat] [--monitor_logs]
+iris-gpubench [--benchmark-image BENCHMARK_IMAGE | --benchmark-command BENCHMARK_COMMAND] [--interval INTERVAL] [--carbon-region CARBON_REGION] [--live-plot] [--export-to-meerkat] [--monitor-logs]
 ```
 
 The following optional arguments are supported:
 
-- `--no_live_monitor`: Disable live monitoring of GPU metrics. Default is enabled.
+- `--no-live-monitor`: Disable live monitoring of GPU metrics. Default is enabled.
 - `--interval <seconds>`: Set the interval for collecting GPU metrics. Default is `5` seconds.
-- `--carbon_region <region>`: Specify the carbon region for the National Grid ESO Regional Carbon Intensity API. Default is `"South England"`.
-- `--no_plot`: Disable plotting of GPU metrics, saves as png. Default is enabled.
-- `--live_plot`: Enable live plotting of GPU metrics and saves plot to png.
-- `--export_to_meerkat`: Enable exporting of collected data to Meerkat DB to be scrapped by the Grafana Dashboard.
-- `--benchmark_image <image>`: Docker container image to run as a benchmark.
-- `--benchmark_command <command>`: Command to run as a benchmark in a `tmux` session. This option allows running benchmarks without Docker.
-- `--monitor_logs`: Enable monitoring of container or tmux logs in addition to GPU metrics.
+- `--carbon-region <region>`: Specify the carbon region for the National Grid ESO Regional Carbon Intensity API. Default is `"South England"`.
+- `--no-plot`: Disable plotting of GPU metrics, saves as png. Default is enabled.
+- `--live-plot`: Enable live plotting of GPU metrics and saves plot to png.
+- `--export-to-meerkat`: Enable exporting of collected data to Meerkat DB to be scrapped by the Grafana Dashboard.
+- `--benchmark-image <image>`: Docker container image to run as a benchmark.
+- `--benchmark-command <command>`: Command to run as a benchmark in a `tmux` session. This option allows running benchmarks without Docker.
+- `--monitor-logs`: Enable monitoring of container or tmux logs in addition to GPU metrics.
 
 ## Help Option
 
@@ -25,7 +25,7 @@ iris-gpubench --help
 
 ## Using the Meerkat Exporter
 
-For the `--export_to_meerkat` option, the Meerkat username, password, and URL must be set as environment variables. Use the following commands:
+For the `--export-to-meerkat` option, the Meerkat username, password, and URL must be set as environment variables. Use the following commands:
 
 ```bash
 export MEERKAT_USERNAME='insert_username'
@@ -36,10 +36,10 @@ export MEERKAT_URL='https://172.16.101.182:8247/write'
 (As of 12/09/24, this is the correct URL.)
 
 ## Useful to know
-- Either `--benchmark_image` or `--benchmark_command` must be provided, but not both. If both options are specified, an error will be raised.
-- Live GPU metrics monitoring and saving a final plot are enabled by default; use `--no_live_monitor` and `--no_plot` to disable them, respectively.
-- To view the available carbon regions, use `--carbon_region ""` to get a list of all regions.
-- To list available Docker images, use `--benchmark_image ""` for a list of images.
+- Either `--benchmark-image` or `--benchmark-command` must be provided, but not both. If both options are specified, an error will be raised.
+- Live GPU metrics monitoring and saving a final plot are enabled by default; use `--no-live-monitor` and `--no-plot` to disable them, respectively.
+- To view the available carbon regions, use `--carbon-region ""` to get a list of all regions.
+- To list available Docker images, use `--benchmark-image ""` for a list of images.
 
 For example commands please see the next page.
 

--- a/docs/example_commands.md
+++ b/docs/example_commands.md
@@ -4,7 +4,7 @@
 ### Example 1: Basic Monitoring with Completion Plot:
 
 ```sh
-iris-gpubench --benchmark_image "synthetic_regression"
+iris-gpubench --benchmark-image "synthetic_regression"
 ```
 
 - **Explanation**: This command runs GPU monitoring while executing the benchmark specified by the Docker image `synthetic_regression`. The system will collect GPU metrics and generate a completion plot at the end. Live monitoring of GPU metrics is enabled by default.
@@ -12,7 +12,7 @@ iris-gpubench --benchmark_image "synthetic_regression"
 ### Example 2: Exporting Data to VictoriaMetrics:
 
 ```sh
-iris-gpubench --benchmark_image "synthetic_regression" --export_to_meerkat
+iris-gpubench --benchmark-image "synthetic_regression" --export-to-meerkat
 ```
 
 - **Explanation**: Similar to the first example, this command runs the `synthetic_regression` Docker image benchmark and collects GPU metrics. Additionally, the collected data is exported to Meerkat for long-term storage and further analysis. This is useful when you need to monitor metrics over time and visualize them later using external tools such as the Grafana Dashboard.
@@ -20,15 +20,15 @@ iris-gpubench --benchmark_image "synthetic_regression" --export_to_meerkat
 ### Example 3: Full Command with All Options:
 
 ```sh
-iris-gpubench --benchmark_image "stemdl_classification" --interval 10 --carbon_region "South England" --live_plot --export_to_meerkat --monitor_logs
+iris-gpubench --benchmark-image "stemdl_classification" --interval 10 --carbon-region "South England" --live-plot --export-to-meerkat --monitor-logs
 ```
 
-- **Explanation**: This is a comprehensive example that runs the `stemdl_classificatio` benchmark in a Docker container and collects GPU metrics at a 10-second interval. The `--carbon_region` flag specifies the carbon intensity region as "South England" to track the carbon emissions impact. Live plotting of GPU metrics is enabled (`--live_plot`), and data will be exported to Meerkat DB via VictoriaMetrics (`--export_to_meerkat`). The `--monitor_logs` flag enables logging of both GPU metrics and the Docker container logs, allowing for deeper analysis of benchmark performance.
+- **Explanation**: This is a comprehensive example that runs the `stemdl_classificatio` benchmark in a Docker container and collects GPU metrics at a 10-second interval. The `--carbon-region` flag specifies the carbon intensity region as "South England" to track the carbon emissions impact. Live plotting of GPU metrics is enabled (`--live-plot`), and data will be exported to Meerkat DB via VictoriaMetrics (`--export-to-meerkat`). The `--monitor-logs` flag enables logging of both GPU metrics and the Docker container logs, allowing for deeper analysis of benchmark performance.
 
 ### Example 4: Run and Monitor Benchmark in the Background without the Need for a Container:
 
 ```sh
-/mantid_imaging_cloud_bench$ iris-gpubench --benchmark_command "./run_1.sh" --live_plot --interval 1
+/mantid_imaging_cloud_bench$ iris-gpubench --benchmark-command "./run_1.sh" --live-plot --interval 1
 ```
 
 - **Explanation**: In this example, a benchmark command (`./run_1.sh`) is executed in the background using `tmux` instead of a Docker container. GPU metrics are collected at 1-second intervals, and live plotting of these metrics is enabled. This is useful when you have a script or binary that doesn't require containerization and want to monitor the system's GPU usage in real-time. Running benchmarks in `tmux` allows the process to continue in the background, making it ideal for long-running benchmarks that don't need constant attention.

--- a/docs/live_monitoring.md
+++ b/docs/live_monitoring.md
@@ -25,7 +25,7 @@ Current GPU Metrics (Tesla V100-PCIE-32GB) as of 2024-09-12 16:53:14:
 ## Monitor Benchmark Container/Tmux Logs
   
 ```sh
-gpu_monitor --benchmark_image "synthetic_regression" --monitor_logs
+gpu_monitor --benchmark-image "synthetic_regression" --monitor-logs
 
 Container Logs:
 <BEGIN> Running benchmark synthetic_regression in training mode
@@ -65,14 +65,14 @@ Gives you saves plot png during every reading so that the metrics can be viewed 
 
 **Example command and Results:**
 ```sh
-gpu_monitor --benchmark_image "stemdl_classification_2gpu" --plot_live
+gpu_monitor --benchmark-image "stemdl_classification_2gpu" --plot_live
 ```
 This command was run on a VM with 2 V100 GPUs for the results in [Collecting Results Section](collecting_results.md#gpu-metrics-timeseries-plot-png).
 
 
 ## (Grafana) Timeseries Plot Live
 
-If the `--export_to_meerkat` tag is used the results can be viewed live from the Grafana Dashboard. Data from multiple VMs can be collected all at once allowing for a live comparison of performance as well.
+If the `--export-to-meerkat` tag is used the results can be viewed live from the Grafana Dashboard. Data from multiple VMs can be collected all at once allowing for a live comparison of performance as well.
 
 See example results [Collecting Results Section](collecting_results.md#gpu-metric-grafana-plots).
 

--- a/iris_gpubench/utils/cli.py
+++ b/iris_gpubench/utils/cli.py
@@ -40,46 +40,46 @@ def parse_arguments(get_carbon_region_names_func):
         description='Monitor GPU metrics and optionally export data to MeerkatDB.'
     )
 
-    parser.add_argument('--no_live_monitor', action='store_true',
+    parser.add_argument('--no-live-monitor', action='store_true',
                         help='Disable live monitoring of GPU metrics (default is enabled).')
 
     parser.add_argument('--interval', type=int, default=MONITOR_INTERVAL,
                         help=f'Interval in seconds for collecting GPU metrics (default is {MONITOR_INTERVAL} seconds).')
 
-    parser.add_argument('--carbon_region', type=str, default='South England',
+    parser.add_argument('--carbon-region', type=str, default='South England',
                         help='Region shorthand for The National Grid ESO Regional Carbon Intensity API (default is "South England").')
 
-    parser.add_argument('--no_plot', action='store_true',
+    parser.add_argument('--no-plot', action='store_true',
                         help='Disable plotting of GPU metrics (default is enabled).')
 
-    parser.add_argument('--live_plot', action='store_true',
+    parser.add_argument('--live-plot', action='store_true',
                         help='Enable live plotting of GPU metrics.')
 
-    parser.add_argument('--export_to_meerkat', action='store_true',
+    parser.add_argument('--export-to-meerkat', action='store_true',
                         help='Enable exporting of collected data to MeerkatDB.')
 
-    parser.add_argument('--benchmark_image', type=str,
+    parser.add_argument('--benchmark-image', type=str,
                         help='Docker container image to run as a benchmark.')
 
-    parser.add_argument('--benchmark_command', type=str,
+    parser.add_argument('--benchmark-command', type=str,
                         help='Command to run as a benchmark in a tmux session.')
 
-    parser.add_argument('--monitor_logs', action='store_true',
+    parser.add_argument('--monitor-logs', action='store_true',
                         help='Enable monitoring of container or tmux logs in addition to GPU metrics.')
 
-    parser.add_argument('--nvidia_nsights', action='store_true',
+    parser.add_argument('--nvidia-nsights', action='store_true',
                         help='Enable Nvidia Nsights to do extra GPU and CPU sampling.')
 
     args = parser.parse_args()
 
     # Validate arguments
     if not args.benchmark_image and not args.benchmark_command:
-        LOGGER.error("Neither '--benchmark_image' nor '--benchmark_command' provided. One must be specified.")
-        parser.error("You must specify either '--benchmark_image' or '--benchmark_command'.")
+        LOGGER.error("Neither '--benchmark-image' nor '--benchmark-command' provided. One must be specified.")
+        parser.error("You must specify either '--benchmark-image' or '--benchmark-command'.")
 
     if args.benchmark_image and args.benchmark_command:
-        LOGGER.error("Both '--benchmark_image' and '--benchmark_command' provided. Only one must be specified.")
-        parser.error("You must specify either '--benchmark_image' or '--benchmark_command', not both.")
+        LOGGER.error("Both '--benchmark-image' and '--benchmark-command' provided. Only one must be specified.")
+        parser.error("You must specify either '--benchmark-image' or '--benchmark-command', not both.")
 
     if args.interval <= 0:
         error_message = f"Monitoring interval must be a positive integer. Provided value: {args.interval}"


### PR DESCRIPTION
Command line flags that are multi-word should use - not _. Changing this everywhere